### PR TITLE
feat/250: remove update rule on comments for admins

### DIFF
--- a/amplify/backend/api/platelet/schema.graphql
+++ b/amplify/backend/api/platelet/schema.graphql
@@ -348,7 +348,7 @@ type Comment
   {allow: private, provider: iam, operations: [read, delete]},
   {allow: groups, groups: ["USER"], operations: [read]},
   {allow: owner, operations: [create, read, delete, update]},
-  {allow: groups, groups: ["ADMIN"], operations: [create, read, delete, update]},
+  {allow: groups, groups: ["ADMIN"], operations: [create, read, delete]},
 ])
 @model {
   id: ID!
@@ -521,6 +521,7 @@ type Statistics {
   numPickedUp: Int
   numNew: Int
   numTest: Int
+
 }
 
 type Query {

--- a/amplify/cli.json
+++ b/amplify/cli.json
@@ -12,7 +12,8 @@
       "transformerversion": 2,
       "suppressschemamigrationprompt": true,
       "securityEnhancementNotification": false,
-      "subscriptionsInheritPrimaryAuth": true
+      "subscriptionsInheritPrimaryAuth": true,
+      "populateOwnerFieldForStaticGroupAuth": true
     },
     "frontend-ios": {
       "enablexcodeintegration": true


### PR DESCRIPTION
Comments need to be amended so that admins cannot update them except for their own.

This needs a new flag added to cli.json `populateOwnerFieldForStaticGroupAuth` otherwise admins cannot update their own comments.

This means old comments made by admins won't be able to be updated by them, only deleted..

It will also need a manual amplify push to all branches with the github action.