### PR TITLE
remove iam perms on models

### DIFF
--- a/amplify/backend/api/platelet/schema.graphql
+++ b/amplify/backend/api/platelet/schema.graphql
@@ -1,7 +1,6 @@
 type Tenant
 @auth(rules: [
 {allow: private, operations: [read]},
-{allow: private, provider: iam, operations: [read]},
 ])
 @model {
   id: ID!

--- a/amplify/backend/api/platelet/schema.graphql
+++ b/amplify/backend/api/platelet/schema.graphql
@@ -78,7 +78,6 @@ type User
 
 type PossibleRiderResponsibilities
 @auth(rules: [
-  {allow: private, provider: iam, operations: [read, delete]},
   {allow: private, operations: [read]},
   {allow: groups, groups: ["ADMIN"], operations: [create, read, delete]},
 ])
@@ -120,7 +119,6 @@ type Vehicle
 
 type VehicleAssignment
 @auth(rules: [
-  {allow: private, provider: iam, operations: [read, delete]},
   {allow: private, operations: [read]},
   {allow: groups, groups: ["ADMIN", "COORDINATOR", "RIDER"], operations: [create, read, delete]},
 ])
@@ -306,7 +304,6 @@ type Task
 
 type TaskAssignee
 @auth(rules: [
-  {allow: private, provider: iam, operations: [read, delete]},
   {allow: private, operations: [read]},
   {allow: groups, groups: ["COORDINATOR", "RIDER", "ADMIN"], operations: [create, read, delete]},
 ])
@@ -346,7 +343,6 @@ type ScheduledTask
 
 type Comment
 @auth(rules: [
-  {allow: private, provider: iam, operations: [read, delete]},
   {allow: groups, groups: ["USER"], operations: [read]},
   {allow: owner, operations: [create, read, delete, update]},
   {allow: groups, groups: ["ADMIN"], operations: [create, read, delete, update]},
@@ -356,14 +352,12 @@ type Comment
   parentId: ID @index(name: "byParent")
   owner: String
     @auth(rules: [
-      {allow: private, provider: iam, operations: [read, delete]},
       {allow: groups, groups: ["USER"], operations: [read]},
       {allow: owner, operations: [create, read, delete]},
       {allow: groups, groups: ["ADMIN"], operations: [create, read, delete]},
     ])
   tenantId: ID! @index(name: "byTenantId")
     @auth(rules: [
-      {allow: private, provider: iam, operations: [read, delete]},
       {allow: groups, groups: ["USER"], operations: [read]},
       {allow: owner, operations: [create, read, delete]},
       {allow: groups, groups: ["ADMIN"], operations: [create, read, delete]},
@@ -373,7 +367,6 @@ type Comment
   visibility: CommentVisibility
   archived: Int @default(value: "0") @index(name: "byArchived")
     @auth(rules: [
-      {allow: private, provider: iam, operations: [read, delete]},
       {allow: groups, groups: ["USER"], operations: [read]},
       {allow: owner, operations: [create, read, delete]},
       {allow: groups, groups: ["ADMIN"], operations: [create, read, delete]},


### PR DESCRIPTION
It seems like the iam rules don't actually do anything custom-roles.json is only needed with the correct roles