### PR TITLE
feat/263: fix new deployments failing because of datasource not existing yet

### DIFF
--- a/amplify/backend/api/platelet/override.ts
+++ b/amplify/backend/api/platelet/override.ts
@@ -1,5 +1,8 @@
 import { AmplifyApiGraphQlResourceStackTemplate } from "@aws-amplify/cli-extensibility-helper";
-import { overrideDataSourceByFileName } from "./overrideHelpers";
+import {
+    addModelStackDependency,
+    overrideDataSourceByFileName,
+} from "./overrideHelpers";
 
 export const override = (resources: AmplifyApiGraphQlResourceStackTemplate) => {
     // prevent an assignment being made on a task if it is archived
@@ -72,4 +75,21 @@ export const override = (resources: AmplifyApiGraphQlResourceStackTemplate) => {
         "ScheduledTask",
         "UserTable"
     );
+    // the overrides above set DataSourceName as a plain string, so CloudFormation
+    // can't infer cross-stack dependencies; without these the model stacks deploy
+    // in parallel and fresh environments fail with "Data source not found"
+    [
+        "Comment",
+        "TaskAssignee",
+        "VehicleAssignment",
+        "PossibleRiderResponsibilities",
+        "Task",
+        "Location",
+        "Vehicle",
+        "ScheduledTask",
+    ].forEach((model) => {
+        addModelStackDependency(resources, model, "User");
+    });
+    // TaskAssignee also uses TaskTable
+    addModelStackDependency(resources, "TaskAssignee", "Task");
 };

--- a/amplify/backend/api/platelet/overrideHelpers.ts
+++ b/amplify/backend/api/platelet/overrideHelpers.ts
@@ -86,6 +86,36 @@ export const overrideDataSource = (
     }
 };
 
+export const addModelStackDependency = (
+    resources: AmplifyApiGraphQlResourceStackTemplate,
+    dependentModelName: string,
+    dependencyModelName: string
+) => {
+    // resolves the AWS::CloudFormation::Stack resource of a model's nested stack;
+    // modelStack is not populated in the override context at push time, so reach
+    // the stack through a resource that is (appsyncFunctions or the datasource)
+    const getNestedStackResource = (modelName: string) => {
+        const model = resources.models[modelName];
+        if (!model) return undefined;
+        const anchor: any =
+            (model.appsyncFunctions &&
+                Object.values(model.appsyncFunctions)[0]) ||
+            model.modelDatasource ||
+            model.modelDDBTable;
+        return anchor && anchor.stack && anchor.stack.nestedStackResource;
+    };
+    const dependent = getNestedStackResource(dependentModelName);
+    const dependency = getNestedStackResource(dependencyModelName);
+    if (!dependent || !dependency) {
+        throw Error(
+            "Could not resolve the nested stack resource for " +
+                (dependent ? dependencyModelName : dependentModelName) +
+                " so the stack dependency cannot be added."
+        );
+    }
+    dependent.addDependsOn(dependency);
+};
+
 export const verifyResolverExistenceByFileName = (
     resources: AmplifyApiGraphQlResourceStackTemplate,
     resolverFileName: string,

--- a/amplify/backend/api/platelet/overrideHelpers.ts
+++ b/amplify/backend/api/platelet/overrideHelpers.ts
@@ -97,7 +97,7 @@ export const addModelStackDependency = (
     const getNestedStackResource = (modelName: string) => {
         const model = resources.models[modelName];
         if (!model) return undefined;
-        const anchor: any =
+        const anchor =
             (model.appsyncFunctions &&
                 Object.values(model.appsyncFunctions)[0]) ||
             model.modelDatasource ||


### PR DESCRIPTION
When referencing another datasource in overrides.ts, add a dependency so that it does not create the override until the referenced datasource exists.