### PR TITLE
Let the user save to upcoming when schedule is on drop off

### DIFF
--- a/src/scenes/GuidedSetup/GuidedSetup.tsx
+++ b/src/scenes/GuidedSetup/GuidedSetup.tsx
@@ -207,23 +207,40 @@ export const GuidedSetup = () => {
     const whoami = useSelector(getWhoami);
 
     useEffect(() => {
-        if (!schedule.pickUp) {
+        if (!schedule.pickUp && !schedule.dropOff) {
             setFutureOrDash(null);
             return;
         }
-        if (futureOrDash) return;
         if (schedule.pickUp) {
             const convertedSchedule = convertScheduleToTaskData(
                 schedule.pickUp
             );
-            const isDueInOneDay = !taskScheduleDueStatus(
+            const isDueInMoreThanOneDay = !taskScheduleDueStatus(
                 convertedSchedule,
                 0,
                 1
             );
-            if (isDueInOneDay) setFutureOrDash("future");
+            if (isDueInMoreThanOneDay) {
+                setFutureOrDash("future");
+            } else {
+                setFutureOrDash(null);
+            }
+        } else if (schedule.dropOff) {
+            const convertedSchedule = convertScheduleToTaskData(
+                schedule.dropOff
+            );
+            const isDueInMoreThanOneDay = !taskScheduleDueStatus(
+                convertedSchedule,
+                0,
+                1
+            );
+            if (isDueInMoreThanOneDay) {
+                setFutureOrDash("future");
+            } else {
+                setFutureOrDash(null);
+            }
         }
-    }, [schedule.pickUp, futureOrDash]);
+    }, [schedule]);
 
     const handleChange = (_: any, newValue: number) => {
         setTabIndex(newValue);

--- a/src/scenes/GuidedSetup/GuidedSetup.tsx
+++ b/src/scenes/GuidedSetup/GuidedSetup.tsx
@@ -218,7 +218,8 @@ export const GuidedSetup = () => {
             const isDueInMoreThanOneDay = !taskScheduleDueStatus(
                 convertedSchedule,
                 0,
-                1
+                1,
+                true
             );
             if (isDueInMoreThanOneDay) {
                 setFutureOrDash("future");
@@ -232,7 +233,8 @@ export const GuidedSetup = () => {
             const isDueInMoreThanOneDay = !taskScheduleDueStatus(
                 convertedSchedule,
                 0,
-                1
+                1,
+                true
             );
             if (isDueInMoreThanOneDay) {
                 setFutureOrDash("future");

--- a/src/utilities/convertScheduleToTaskData.ts
+++ b/src/utilities/convertScheduleToTaskData.ts
@@ -3,11 +3,13 @@ import { Schedule } from "../scenes/sharedTaskComponents/PickUpAndDeliverSchedul
 import { calculateBetweenIsOneDay } from "../utilities/calculateBetweenIsOneDay";
 
 export const convertScheduleToTaskData = (
-    input: Schedule | null | undefined
+    schedule: Schedule | null | undefined
 ): models.Schedule | null => {
-    if (!input) return null;
-    const schedule = { ...input };
-    const scheduledDate = schedule.date || new Date("2099-01-01");
+    if (!schedule) return null;
+    // clone the date so setting the time doesn't mutate the caller's Date
+    const scheduledDate = schedule.date
+        ? new Date(schedule.date)
+        : new Date("2099-01-01");
     let scheduledDateSecond = null;
     const hour = schedule?.timePrimary?.split(":")[0];
     const minute = schedule?.timePrimary?.split(":")[1];

--- a/src/utilities/convertScheduleToTaskData.ts
+++ b/src/utilities/convertScheduleToTaskData.ts
@@ -3,9 +3,10 @@ import { Schedule } from "../scenes/sharedTaskComponents/PickUpAndDeliverSchedul
 import { calculateBetweenIsOneDay } from "../utilities/calculateBetweenIsOneDay";
 
 export const convertScheduleToTaskData = (
-    schedule: Schedule | null | undefined
+    input: Schedule | null | undefined
 ): models.Schedule | null => {
-    if (!schedule) return null;
+    if (!input) return null;
+    const schedule = { ...input };
     const scheduledDate = schedule.date || new Date("2099-01-01");
     let scheduledDateSecond = null;
     const hour = schedule?.timePrimary?.split(":")[0];

--- a/src/utilities/taskScheduleDueStatus.test.ts
+++ b/src/utilities/taskScheduleDueStatus.test.ts
@@ -45,4 +45,34 @@ describe("taskScheduleDueStatus", () => {
         const result = taskScheduleDueStatus(schedule, 1);
         expect(result).toEqual(true);
     });
+    test("anytime tomorrow is due within one day when using the window start", () => {
+        const schedule = new models.Schedule({
+            relation: models.TimeRelation.ANYTIME,
+            timePrimary: "2021-01-02T12:00:00.000Z",
+        });
+        expect(taskScheduleDueStatus(schedule, 0, 1, true)).toEqual(true);
+        // default end of window behaviour still counts it as not due
+        expect(taskScheduleDueStatus(schedule, 0, 1)).toEqual(false);
+    });
+    test("anytime the day after tomorrow is not due within one day when using the window start", () => {
+        const schedule = new models.Schedule({
+            relation: models.TimeRelation.ANYTIME,
+            timePrimary: "2021-01-03T12:00:00.000Z",
+        });
+        expect(taskScheduleDueStatus(schedule, 0, 1, true)).toEqual(false);
+    });
+    test("after a time tomorrow uses timePrimary when using the window start", () => {
+        const dueSchedule = new models.Schedule({
+            relation: models.TimeRelation.AFTER,
+            timePrimary: "2021-01-02T09:00:00.000Z",
+        });
+        expect(taskScheduleDueStatus(dueSchedule, 0, 1, true)).toEqual(true);
+        const notDueSchedule = new models.Schedule({
+            relation: models.TimeRelation.AFTER,
+            timePrimary: "2021-01-02T14:00:00.000Z",
+        });
+        expect(taskScheduleDueStatus(notDueSchedule, 0, 1, true)).toEqual(
+            false
+        );
+    });
 });

--- a/src/utilities/taskScheduleDueStatus.ts
+++ b/src/utilities/taskScheduleDueStatus.ts
@@ -25,12 +25,10 @@ const taskScheduleDueStatus = (
     ) {
         if (useWindowStart) {
             if (schedule?.relation === models.TimeRelation.ANYTIME) {
-                scheduleDate.setHours(0);
-                scheduleDate.setMinutes(0);
+                scheduleDate.setHours(0, 0, 0, 0);
             }
         } else {
-            scheduleDate.setHours(23);
-            scheduleDate.setMinutes(59);
+            scheduleDate.setHours(23, 59, 59, 999);
         }
     }
     scheduleDate.setUTCHours(scheduleDate.getUTCHours() - hours);

--- a/src/utilities/taskScheduleDueStatus.ts
+++ b/src/utilities/taskScheduleDueStatus.ts
@@ -3,7 +3,12 @@ import * as models from "../models";
 const taskScheduleDueStatus = (
     schedule: models.Schedule | null,
     hours: number = 0,
-    days: number = 0
+    days: number = 0,
+    // ANYTIME and AFTER schedules span a window rather than a point in time;
+    // by default they count as due at the end of the window (23:59), which
+    // suits deadline warnings. Pass useWindowStart to count them as due from
+    // when they first become actionable instead.
+    useWindowStart: boolean = false
 ) => {
     if (!schedule) {
         return false;
@@ -18,8 +23,15 @@ const taskScheduleDueStatus = (
             schedule?.relation as models.TimeRelation
         )
     ) {
-        scheduleDate.setHours(23);
-        scheduleDate.setMinutes(59);
+        if (useWindowStart) {
+            if (schedule?.relation === models.TimeRelation.ANYTIME) {
+                scheduleDate.setHours(0);
+                scheduleDate.setMinutes(0);
+            }
+        } else {
+            scheduleDate.setHours(23);
+            scheduleDate.setMinutes(59);
+        }
     }
     scheduleDate.setUTCHours(scheduleDate.getUTCHours() - hours);
     scheduleDate.setUTCDate(scheduleDate.getUTCDate() - days);

--- a/src/utilities/taskScheduleDueStatus.ts
+++ b/src/utilities/taskScheduleDueStatus.ts
@@ -25,10 +25,10 @@ const taskScheduleDueStatus = (
     ) {
         if (useWindowStart) {
             if (schedule?.relation === models.TimeRelation.ANYTIME) {
-                scheduleDate.setHours(0, 0, 0, 0);
+                scheduleDate.setUTCHours(0, 0, 0, 0);
             }
         } else {
-            scheduleDate.setHours(23, 59, 59, 999);
+            scheduleDate.setUTCHours(23, 59, 59, 999);
         }
     }
     scheduleDate.setUTCHours(scheduleDate.getUTCHours() - hours);


### PR DESCRIPTION
If the drop off is due in the future, prompt the user to save it to upcoming.

Copy date data in src/utilities/convertScheduleToTaskData.ts so that it is not mutated in place.

Improve logic in src/utilities/taskScheduleDueStatus.ts so that a task due anytime tomorrow is properly saved to the dashboard.